### PR TITLE
[#13] | fixes the solr schema xml parsing error in newer solr schema

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.7</source>
+          <target>1.7</target>
         </configuration>
       </plugin>
 

--- a/src/main/java/com/sematext/searchschemer/reader/solr/SolrDynamicFieldsDefinitionReader.java
+++ b/src/main/java/com/sematext/searchschemer/reader/solr/SolrDynamicFieldsDefinitionReader.java
@@ -1,11 +1,10 @@
 package com.sematext.searchschemer.reader.solr;
 
-import java.io.File;
-import java.util.ArrayList;
-
+import com.sematext.searchschemer.index.solr.SolrFieldAttributes;
 import org.apache.commons.digester3.Digester;
 
-import com.sematext.searchschemer.index.solr.SolrFieldAttributes;
+import java.io.File;
+import java.util.ArrayList;
 
 /**
  * Reader for static fields defined in Solr schema.xml file.
@@ -31,9 +30,9 @@ public class SolrDynamicFieldsDefinitionReader extends SolrStaticFieldsDefinitio
   protected void initializeDigester() {
     digester = new Digester();
     digester.setNamespaceAware(true);
-    digester.addObjectCreate("schema/fields", ArrayList.class);
-    digester.addObjectCreate("schema/fields/dynamicField", SolrFieldAttributes.class);
-    digester.addSetProperties("schema/fields/dynamicField/");
-    digester.addSetNext("schema/fields/dynamicField", "add");
+    digester.addObjectCreate("schema/", ArrayList.class);
+    digester.addObjectCreate("schema/dynamicField", SolrFieldAttributes.class);
+    digester.addSetProperties("schema/dynamicField/");
+    digester.addSetNext("schema/dynamicField", "add");
   }
 }

--- a/src/main/java/com/sematext/searchschemer/reader/solr/SolrStaticFieldsDefinitionReader.java
+++ b/src/main/java/com/sematext/searchschemer/reader/solr/SolrStaticFieldsDefinitionReader.java
@@ -1,14 +1,13 @@
 package com.sematext.searchschemer.reader.solr;
 
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-
+import com.sematext.searchschemer.index.FieldAttributes;
+import com.sematext.searchschemer.index.solr.SolrFieldAttributes;
 import org.apache.commons.digester3.Digester;
 import org.xml.sax.SAXException;
 
-import com.sematext.searchschemer.index.FieldAttributes;
-import com.sematext.searchschemer.index.solr.SolrFieldAttributes;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
 
 /**
  * Reader for static fields defined in Solr schema.xml file.
@@ -53,9 +52,9 @@ public class SolrStaticFieldsDefinitionReader {
   protected void initializeDigester() {
     digester = new Digester();
     digester.setNamespaceAware(true);
-    digester.addObjectCreate("schema/fields", ArrayList.class);
-    digester.addObjectCreate("schema/fields/field", SolrFieldAttributes.class);
-    digester.addSetProperties("schema/fields/field/");
-    digester.addSetNext("schema/fields/field", "add");
+    digester.addObjectCreate("schema/", ArrayList.class);
+    digester.addObjectCreate("schema/field", SolrFieldAttributes.class);
+    digester.addSetProperties("schema/field/");
+    digester.addSetNext("schema/field", "add");
   }
 }

--- a/src/test/resources/solr/test_schema.xml
+++ b/src/test/resources/solr/test_schema.xml
@@ -32,27 +32,24 @@
     </fieldType>
   </types>
 
+  <field name="id" type="string" indexed="true" stored="true"
+    required="true" />
+  <field name="name" type="text" indexed="true" stored="true" />
+  <field name="cat" type="string" indexed="true" stored="true"
+    multiValued="true" />
+  <field name="features" type="text" indexed="true" stored="true"
+    multiValued="true" />
+  <field name="weight" type="float" indexed="true" stored="true" />
+  <field name="price" type="float" indexed="true" stored="true" />
+  <field name="popularity" type="int" indexed="true" stored="true" />
+  <field name="inStock" type="boolean" indexed="true" stored="true" />
 
-  <fields>
-    <field name="id" type="string" indexed="true" stored="true"
-      required="true" />
-    <field name="name" type="text" indexed="true" stored="true" />
-    <field name="cat" type="string" indexed="true" stored="true"
-      multiValued="true" />
-    <field name="features" type="text" indexed="true" stored="true"
-      multiValued="true" />
-    <field name="weight" type="float" indexed="true" stored="true" />
-    <field name="price" type="float" indexed="true" stored="true" />
-    <field name="popularity" type="int" indexed="true" stored="true" />
-    <field name="inStock" type="boolean" indexed="true" stored="true" />
-
-    <dynamicField name="*_i" type="int" indexed="true"
-      stored="true" />
-    <dynamicField name="*_s" type="string" indexed="true"
-      stored="true" />
-    <dynamicField name="*_l" type="long" indexed="true"
-      stored="true" />
-  </fields>
+  <dynamicField name="*_i" type="int" indexed="true"
+    stored="true" />
+  <dynamicField name="*_s" type="string" indexed="true"
+    stored="true" />
+  <dynamicField name="*_l" type="long" indexed="true"
+    stored="true" />
 
   <uniqueKey>id</uniqueKey>
 

--- a/src/test/resources/solr/test_schema_additional_attributes.xml
+++ b/src/test/resources/solr/test_schema_additional_attributes.xml
@@ -32,12 +32,9 @@
     </fieldType>
   </types>
 
-
-  <fields>
-    <field name="id" type="text" indexed="true" stored="true"
-      required="true" omitNorms="true" omitTermFreqAndPositions="true"
-      boost="2.0" />
-  </fields>
+  <field name="id" type="text" indexed="true" stored="true"
+    required="true" omitNorms="true" omitTermFreqAndPositions="true"
+    boost="2.0" />
 
   <uniqueKey>id</uniqueKey>
 

--- a/src/test/resources/solr/test_schema_small.xml
+++ b/src/test/resources/solr/test_schema_small.xml
@@ -32,11 +32,8 @@
     </fieldType>
   </types>
 
-
-  <fields>
-    <field name="id" type="string" indexed="true" stored="true"
-      required="true" />
-  </fields>
+  <field name="id" type="string" indexed="true" stored="true"
+    required="true" />
 
   <uniqueKey>id</uniqueKey>
 

--- a/src/test/resources/solr/test_schema_small_dynamic.xml
+++ b/src/test/resources/solr/test_schema_small_dynamic.xml
@@ -32,13 +32,10 @@
     </fieldType>
   </types>
 
-
-  <fields>
-    <field name="id" type="string" indexed="true" stored="true"
-      required="true" />
-    <dynamicField name="*_i" type="int" indexed="true"
-      stored="true" />
-  </fields>
+  <field name="id" type="string" indexed="true" stored="true"
+    required="true" />
+  <dynamicField name="*_i" type="int" indexed="true"
+    stored="true" />
 
   <uniqueKey>id</uniqueKey>
 

--- a/src/test/resources/solr/test_schema_small_string_text.xml
+++ b/src/test/resources/solr/test_schema_small_string_text.xml
@@ -32,10 +32,7 @@
     </fieldType>
   </types>
 
-
-  <fields>
-    <field name="id" type="text" indexed="true" stored="true" required="true" />
-  </fields>
+  <field name="id" type="text" indexed="true" stored="true" required="true" />
 
   <uniqueKey>id</uniqueKey>
 


### PR DESCRIPTION
fixes the issue where solr schema xml parsing was failing due to removal of fields tag in newer solr schema xml structure

for e.g.
NEW schema structure
<schema>
<field.../>
<field.../>
</schema>

OLD schema structure
<schema>
<fields>
<field.../>
<field.../>
</fields>
</schema>

